### PR TITLE
Fix the javascript unit tests to use PhantomJS 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "karma-cli": "0.0.4",
     "karma-coverage": "^0.2.7",
     "karma-jasmine": "^0.3.5",
-    "karma-phantomjs-launcher": "^0.1.4",
-    "jasmine-core": "2.3.4"
+    "karma-phantomjs-launcher": "^1.0.0",
+    "jasmine-core": "2.3.4",
+    "phantomjs-prebuilt": "^2.1.4"
   }
 }

--- a/test/controllers/sidebar.test.js
+++ b/test/controllers/sidebar.test.js
@@ -1,11 +1,54 @@
 'use strict';
  
-describe('sidebarController', function(){
-  var scope, controller;
+describe('sidebarController tests', function(){
+  var scope, controller, profileService;              
 
-  beforeEach(angular.mock.module('copayApp.controllers'));
-
-  it('wallet selection', function(){
-    expect(true).not.toBeUndefined();
+  beforeEach(function() {
+      angular.mock.module('copayApp.controllers');
+      angular.mock.module('stateMock');
+      angular.mock.module('ngLodash');
+      angular.mock.module('copayApp.services');
+      angular.mock.module('bwcModule');
+      angular.mock.module('gettext');
+      angular.mock.module('angularMoment');
   });
+
+  beforeEach(
+      angular.mock.inject(function($rootScope, $controller, _profileService_) {
+        profileService = _profileService_;
+        scope = $rootScope.$new();
+        controller = $controller('sidebarController', {
+            $scope: scope,
+            profileService: profileService
+        });
+      })
+  );
+
+  it('wallet selection', function() {
+    expect(controller).toBeDefined();
+    expect(controller.walletSelection).toBe(false);
+  });
+
+  it('is able to switch wallets via the profile service.', function(){
+     spyOn(profileService, 'setAndStoreFocus');
+     var currentWalletId = '00000000-0000-0000-0000-000000000001';
+     var newWalletId = '00000000-0000-0000-0000-000000000002';
+
+     controller.switchWallet(newWalletId, currentWalletId);
+
+     expect(profileService.setAndStoreFocus).toHaveBeenCalled();
+     expect(profileService.setAndStoreFocus)
+        .toHaveBeenCalledWith(newWalletId, jasmine.any(Function));    
+  });
+
+  it('does not switch wallets when the new wallet is already the current wallet', 
+     function() {
+        spyOn(profileService, 'setAndStoreFocus');
+        var currentWalletId = '00000000-0000-0000-0000-000000000001';
+
+        controller.switchWallet(currentWalletId, currentWalletId);
+
+        expect(profileService.setAndStoreFocus).not.toHaveBeenCalled(); 
+    }
+  );
 });

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -15,6 +15,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
+	  'bower_components/fastclick/lib/fastclick.js',
       'bower_components/qrcode-generator/js/qrcode.js',
       'bower_components/qrcode-decoder-js/lib/qrcode-decoder.js',
       'bower_components/moment/min/moment-with-locales.js',
@@ -28,6 +29,7 @@ module.exports = function(config) {
       'bower_components/angular-qrcode/qrcode.js',
       'bower_components/angular-gettext/dist/angular-gettext.js',
       'bower_components/angular-touch/angular-touch.js',
+	  'bower_components/angular-bitcore-wallet-client/angular-bitcore-wallet-client.js',
       'bower_components/angular-ui-switch/angular-ui-switch.js',
       'node_modules/angular-mocks/angular-mocks.js',
       'src/js/**/*.js',


### PR DESCRIPTION
The javascript unit tests could not be made for a while because of an issue in the angular bitcore wallet client requiring phantomjs version 2.
Since the new launcher was released a while ago already I updated the karma phantom launcher and created some example tests to prove we can create the tests again. 
I tested loading the entire copayApp module in the unit tests to see if everything was able to initialize. This worked, however the $log service currently dumps the entire stack trace of where the $log method was called from in the console when running the tests at the moment. 
This creates quite a lot of clutter in the console. This does not occur for the chrome launcher so it has something to do with the new phantomjs launcher. I don't think you want to load the entire module for unit testing anyway so I don't see that as a big problem as of now. It's nice that we can actually start testing the code.

I'll start testing the code when this is accepted.
