### PR TITLE
Fix several places where the desktop version conflicts with upstream.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -216,7 +216,7 @@ module.exports = function(grunt) {
           expand: true,
           cwd: 'webkitbuilds/',
           src: ['.desktop', '../public/img/icons/favicon.ico', '../public/img/icons/icon-256.png'],
-          dest: 'webkitbuilds/Copay/linux64/',
+          dest: 'webkitbuilds/CopayDecred/linux64/',
           flatten: true,
           filter: 'isFile'
         }],
@@ -233,7 +233,7 @@ module.exports = function(grunt) {
     },
     nodewebkit: {
       options: {
-        appName: 'Copay',
+        appName: 'CopayDecred',
         platforms: ['win64', 'osx64', 'linux64'],
         buildDir: './webkitbuilds',
         version: '0.12.2',
@@ -248,7 +248,7 @@ module.exports = function(grunt) {
           archive: './webkitbuilds/Copay-linux.zip'
         },
         expand: true,
-        cwd: './webkitbuilds/Copay/linux64/',
+        cwd: './webkitbuilds/CopayDecred/linux64/',
         src: ['**/*'],
         dest: 'copay-linux/'
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "copay",
+  "name": "copaydecred",
   "description": "A multisignature decred wallet",
-  "author": "BitPay",
+  "author": "decred.org",
   "version": "2.1.0",
   "androidVersionCode": "109",
   "keywords": [

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -460,7 +460,7 @@ angular.module('copayApp').config(function(historicLogProvider, $provide, $logPr
         type: "menubar"
       });
       try {
-        nativeMenuBar.createMacBuiltin("Copay");
+        nativeMenuBar.createMacBuiltin("CopayDecred");
       } catch (e) {
         $log.debug('This is not OSX');
       }

--- a/webkitbuilds/build-osx.sh
+++ b/webkitbuilds/build-osx.sh
@@ -16,10 +16,10 @@ if [ -d "$dir" ]; then
 fi
 
 # set up your app name, architecture, and background image file name
-APP_NAME="Copay"
+APP_NAME="CopayDecred"
 DMG_BACKGROUND_IMG="Background.png"
 
-PATH_NAME="Copay/osx64/"
+PATH_NAME="CopayDecred/osx64/"
 # you should not need to change these
 APP_EXE="${PATH_NAME}${APP_NAME}.app/Contents/MacOS/nwjs"
 


### PR DESCRIPTION
Make name in title bar on mac different.

Change app name so it uses a different directory for local files than
upstream copay.

Resolves #41 (along with PR #42)
